### PR TITLE
Add an argument to raise_error to avoid false positives.

### DIFF
--- a/spec/match_hash_spec.rb
+++ b/spec/match_hash_spec.rb
@@ -39,7 +39,7 @@ describe MatchHash do
   it "A hash do not match B hash and occured raise_error" do
     expect do
       expect(@A).to match_hash(@B)
-    end.to raise_error
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
 end


### PR DESCRIPTION
Otherwise, the following warning is shown:

    WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<RSpec::Expectations::ExpectationNotMetError: